### PR TITLE
Autodetect service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 
 vendor/
+cover

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,23 @@
+# encoding: utf-8
+
+task :glide do
+  sh 'glide install'
+end
+
+desc 'Run the unit tests locally'
+task :test do
+  sh 'go test -v -race -cover'
+end
+
+desc 'Generate coverage data for the tests and display it in the default browser'
+task :test_coverage do
+  begin
+    sh 'mkdir coverage'
+    sh 'go test -race -coverprofile=coverage/c.out'
+    sh 'go tool cover -html=coverage/c.out'
+  ensure
+    sh 'rm -rf coverage'
+  end
+end
+
+task :default => [:test]

--- a/glide.lock
+++ b/glide.lock
@@ -1,21 +1,30 @@
+<<<<<<< Updated upstream
 hash: 117123ecdf26daf8d567006c1fb85f1a588fb9421c2ea6df9844f1eec5fa0b92
 updated: 2017-01-24T11:58:29.116197856+01:00
+=======
+hash: 15058da6aee5d2c9bd7289fafd8c7be1114d13fa4bea7c8592fb1ac9405aac27
+updated: 2017-02-10T13:59:02.841518169+01:00
+>>>>>>> Stashed changes
 imports:
 - name: github.com/gorilla/context
-  version: aed02d124ae4a0e94fea4541c8effd05bf0c8296
+  version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/m4rw3r/uuid
   version: 00c72d48d5aaaf3058e26d9641164c43ba239f33
 - name: github.com/Sirupsen/logrus
+<<<<<<< Updated upstream
   version: a283a10442df8dc09befd873fab202bf8a253d6a
 - name: github.com/tylerb/graceful
   version: 0e9129e9c6d47da90dc0c188b26bd7bb1dab53cd
+=======
+  version: c078b1e43f58d563c74cebe63c85789e76ddb627
+>>>>>>> Stashed changes
 - name: golang.org/x/sys
-  version: a646d33e2ee3172a661fc09bca23bb4889a41bc8
+  version: ca83bd2cb9abb47839b50eb4da612f00158f5870
   subpackages:
   - unix
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib
@@ -23,7 +32,7 @@ testImports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: d77da356e56a7428ad25149ca77381849a6a5232
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
   - require

--- a/glide.lock
+++ b/glide.lock
@@ -1,23 +1,14 @@
-<<<<<<< Updated upstream
 hash: 117123ecdf26daf8d567006c1fb85f1a588fb9421c2ea6df9844f1eec5fa0b92
-updated: 2017-01-24T11:58:29.116197856+01:00
-=======
-hash: 15058da6aee5d2c9bd7289fafd8c7be1114d13fa4bea7c8592fb1ac9405aac27
-updated: 2017-02-10T13:59:02.841518169+01:00
->>>>>>> Stashed changes
+updated: 2017-02-10T15:11:33.047451741+01:00
 imports:
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/m4rw3r/uuid
   version: 00c72d48d5aaaf3058e26d9641164c43ba239f33
 - name: github.com/Sirupsen/logrus
-<<<<<<< Updated upstream
-  version: a283a10442df8dc09befd873fab202bf8a253d6a
+  version: c078b1e43f58d563c74cebe63c85789e76ddb627
 - name: github.com/tylerb/graceful
   version: 0e9129e9c6d47da90dc0c188b26bd7bb1dab53cd
-=======
-  version: c078b1e43f58d563c74cebe63c85789e76ddb627
->>>>>>> Stashed changes
 - name: golang.org/x/sys
   version: ca83bd2cb9abb47839b50eb4da612f00158f5870
   subpackages:

--- a/http_handler.go
+++ b/http_handler.go
@@ -10,7 +10,7 @@ import (
 	"github.com/tylerb/graceful"
 )
 
-// This middleware is defined for convenience to avoid the long chain of
+// TracingHandlerFunc is middleware defined for convenience to avoid the long chain of
 // middleware invocations on each endpoint. It wraps a http.HandlerFunc
 // adding both, request-tracing and profiling capabilities.
 // This function can be used to enhance single endpoints in a http-server
@@ -19,7 +19,7 @@ func TracingHandlerFunc(h http.HandlerFunc) http.HandlerFunc {
 	return TracingMiddleware(LoggingMiddleWare(h))
 }
 
-// This middleware wraps a http.Handler adding request-tracing and
+// Trace is middleware that wraps a http.Handler adding request-tracing and
 // profiling capabilities.
 // This function can be used to enhance a http router adding extra
 // capabilities to all its enpoints.

--- a/request_logging.go
+++ b/request_logging.go
@@ -20,8 +20,8 @@ func SetDebug(d bool) {
 	debug = d
 }
 
-// unexported key types
-type requestKeyType string // This avois collisions with other gorilla context keys
+// non-exported key types
+type requestKeyType string // This avoids collisions with other gorilla context keys
 type loggingKeyType string // This allows discriminating httptrace-logging keys from others
 
 const requestKey requestKeyType = "httptrace"


### PR DESCRIPTION
Adds rakefile, autodetects service name from env variables, updates dependencies, populates request id header that HAproxy uses