### PR TITLE
Fix graceful shutdown

### DIFF
--- a/http_handler.go
+++ b/http_handler.go
@@ -2,6 +2,7 @@ package httptrace
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -65,7 +66,7 @@ func ListenAndServe(addr string, handler http.Handler) error {
 
 	var err error
 	go func() {
-		if err = srv.ListenAndServe(); err != nil {
+		if err = srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Error("Server error: ", err)
 			close(stopChan)
 		}


### PR DESCRIPTION
This lib is used in the nordea service and every time the service stops gracefully two errors are logged, followed by a nice fatal too.

Thought is was simpler to just update this lib rather than refactor it out of the nordea service.